### PR TITLE
Enhance Service Dependency with Healthcheck Condition

### DIFF
--- a/services/adguardhome/docker-compose.yml
+++ b/services/adguardhome/docker-compose.yml
@@ -45,7 +45,8 @@ services:
       - ${PWD}/${SERVICE}/workdir:/opt/adguardhome/work # Work directory for Adguard Home - you may need to change the path
       - ${PWD}/${SERVICE}/configdir:/opt/adguardhome/conf # Config directory for Adguard Home - you may need to change the path
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/bazarr/docker-compose.yml
+++ b/services/bazarr/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       - ${PWD}/${SERVICE}/media/movies:/movies
       - ${PWD}/${SERVICE}/media/tvseries:/tv
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/beszel/agent/docker-compose.yml
+++ b/services/beszel/agent/docker-compose.yml
@@ -44,7 +44,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro # Read-only access to the docker.sock
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/beszel/hub/docker-compose.yml
+++ b/services/beszel/hub/docker-compose.yml
@@ -45,7 +45,8 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/beszel_data:/beszel_data  # Work directory for Beszel Hub - you may need to change the path
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/changedetection/docker-compose.yml
+++ b/services/changedetection/docker-compose.yml
@@ -45,7 +45,8 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/datastore:/datastore
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/cyberchef/docker-compose.yml
+++ b/services/cyberchef/docker-compose.yml
@@ -41,7 +41,8 @@ services:
     environment:
       - TZ=Europe/Amsterdam
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/ddns-updater/docker-compose.yml
+++ b/services/ddns-updater/docker-compose.yml
@@ -66,7 +66,8 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/data:/updater/data
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/dozzle/docker-compose.yml
+++ b/services/dozzle/docker-compose.yml
@@ -44,7 +44,8 @@ services:
       - ${PWD}/${SERVICE}/dozzle-data:/data
       - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/excalidraw/docker-compose.yml
+++ b/services/excalidraw/docker-compose.yml
@@ -45,7 +45,8 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/app/config:/config
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/gokapi/docker-compose.yml
+++ b/services/gokapi/docker-compose.yml
@@ -44,7 +44,8 @@ services:
       - ${PWD}/${SERVICE}/gokapi-data:/app/data
       - ${PWD}/${SERVICE}/gokapi-config:/app/config
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/homarr/docker-compose.yml
+++ b/services/homarr/docker-compose.yml
@@ -48,7 +48,8 @@ services:
       - ${PWD}/homarr/icons:/app/public/icons
       - ${PWD}/homarr/data:/data
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/isley/docker-compose.yml
+++ b/services/isley/docker-compose.yml
@@ -44,7 +44,8 @@ services:
       - ${PWD}/${SERVICE}/isley-db:/app/data
       - ${PWD}/${SERVICE}/isley-uploads:/app/uploads
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/it-tools/docker-compose.yml
+++ b/services/it-tools/docker-compose.yml
@@ -41,7 +41,8 @@ services:
     environment:
       - TZ=Europe/Amsterdam
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/jellyfin/docker-compose.yml
+++ b/services/jellyfin/docker-compose.yml
@@ -49,7 +49,8 @@ services:
       - ${PWD}/media/tvseries:/data/tvshows
       - ${PWD}/media/movies:/data/movies
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/languagetool/docker-compose.yml
+++ b/services/languagetool/docker-compose.yml
@@ -46,7 +46,8 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ngrams:/ngrams
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/nextcloud/docker-compose.yml
+++ b/services/nextcloud/docker-compose.yml
@@ -47,8 +47,10 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/nextcloud_data/:/var/www/html
     depends_on:
-      - tailscale
-      - db
+      tailscale:
+        condition: service_healthy
+      db:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "apache2"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/nodered/docker-compose.yml
+++ b/services/nodered/docker-compose.yml
@@ -45,7 +45,8 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/app/config:/data
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/pihole/docker-compose.yml
+++ b/services/pihole/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       - ${PWD}/${SERVICE}/etc-dnsmasq.d:/etc/dnsmasq.d
     #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "pihole-FTL"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/pingvin-share/docker-compose.yml
+++ b/services/pingvin-share/docker-compose.yml
@@ -45,7 +45,8 @@ services:
       - ${PWD}/${SERVICE}/data:/opt/app/backend/data
       - ${PWD}/${SERVICE}/images:/opt/app/frontend/public/img
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "caddy"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/plex/docker-compose.yml
+++ b/services/plex/docker-compose.yml
@@ -49,7 +49,8 @@ services:
       - ${PWD}/${SERVICE}/media/tvseries:/tv
       - ${PWD}/${SERVICE}/media/movies:/movies
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "Plex Media Server"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/portainer/docker-compose.yml
+++ b/services/portainer/docker-compose.yml
@@ -46,7 +46,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${PWD}/${SERVICE}/portainer_data:/data
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/qbittorrent/docker-compose.yml
+++ b/services/qbittorrent/docker-compose.yml
@@ -48,7 +48,8 @@ services:
       - ${PWD}/${SERVICE}/config:/config
       - ${PWD}/${SERVICE}/downloads:/downloads
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/radarr/docker-compose.yml
+++ b/services/radarr/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       - ${PWD}/${SERVICE}/media/movies:/movies #Optional
       - ${PWD}/${SERVICE}/downloads:/downloads #Optional
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/resilio-sync/docker-compose.yml
+++ b/services/resilio-sync/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       - ${PWD}/${SERVICE}/downloads:/downloads
       - ${PWD}/${SERVICE}/data:/sync
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "rslsync"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/searxng/docker-compose.yml
+++ b/services/searxng/docker-compose.yml
@@ -58,8 +58,10 @@ services:
         max-size: "1m"
         max-file: "1"
     depends_on:
-      - tailscale
-      - redis
+      tailscale:
+        condition: service_healthy
+      redis:
+        condition: service_started
 
   redis:
     container_name: redis-searxng

--- a/services/slink/docker-compose.yml
+++ b/services/slink/docker-compose.yml
@@ -61,7 +61,8 @@ services:
       - ${PWD}/${SERVICE}/var/data:/app/var/data
       - ${PWD}/${SERVICE}/images:/app/slink/images
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/sonarr/docker-compose.yml
+++ b/services/sonarr/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       - ${PWD}/${SERVICE}/media/tvseries:/tv
       - ${PWD}/${SERVICE}/downloads:/downloads
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/stirlingpdf/docker-compose.yml
+++ b/services/stirlingpdf/docker-compose.yml
@@ -48,7 +48,8 @@ services:
 #      - ${PWD}/${SERVICE}/customFiles:/customFiles/ # May be enabled if desired
 #      - ${PWD}/${SERVICE}/logs:/logs/ # May be enabled if desired
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "app.jar"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/tautulli/docker-compose.yml
+++ b/services/tautulli/docker-compose.yml
@@ -45,7 +45,8 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/app/config:/config
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/technitium/docker-compose.yml
+++ b/services/technitium/docker-compose.yml
@@ -69,7 +69,8 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/app/config:/config
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/traefik/docker-compose.yml
+++ b/services/traefik/docker-compose.yml
@@ -43,7 +43,8 @@ services:
       - PGID=1000
       - TZ=Europe/Amsterdam
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check

--- a/services/uptime-kuma/docker-compose.yml
+++ b/services/uptime-kuma/docker-compose.yml
@@ -46,5 +46,6 @@ services:
       - ${PWD}/${SERVICE}/uptime-kuma-data:/app/data # uptime-kuma data/configuration folder
       - /var/run/docker.sock:/var/run/docker.sock:ro # Read-only access to the docker.sock
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     restart: always

--- a/services/vaultwarden/docker-compose.yml
+++ b/services/vaultwarden/docker-compose.yml
@@ -44,5 +44,6 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/vw-data:/data
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     restart: always

--- a/templates/service-template/docker-compose.yml
+++ b/templates/service-template/docker-compose.yml
@@ -45,7 +45,8 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/app/config:/config
     depends_on:
-      - tailscale
+      tailscale:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
       interval: 1m # How often to perform the check


### PR DESCRIPTION
Suggestion:
Add condition: 'service_healthy' to 'depends_on'.

Previously, the 'depends_on' configuration did not include the 'condition: service_healthy' for the Tailscale container. With the recent update improving the Tailscale container's healthcheck, this addition ensures the dependent service waits for Tailscale to be fully operational before starting. This change improves the reliability and stability of the service dependency chain.

I'd be happy to add this to every service in the repo should you like me to?

Cheers, Adam