### PR TITLE
Fix for tstun.New("tailscale0"): operation not permitted

### DIFF
--- a/services/adguardhome/docker-compose.yml
+++ b/services/adguardhome/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/bazarr/docker-compose.yml
+++ b/services/bazarr/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/beszel/agent/docker-compose.yml
+++ b/services/beszel/agent/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/beszel/hub/docker-compose.yml
+++ b/services/beszel/hub/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/changedetection/docker-compose.yml
+++ b/services/changedetection/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     image: tailscale/tailscale:latest # Image to be used
     container_name: ${SERVICE} # Name for local container management
     hostname: ${SERVICE} # Name used within your Tailscale environment
-    privileged: true
     environment:
       - TS_AUTHKEY=${TS_AUTHKEY}
       - TS_STATE_DIR=/var/lib/tailscale
@@ -17,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/changedetection/docker-compose.yml
+++ b/services/changedetection/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: tailscale/tailscale:latest # Image to be used
     container_name: ${SERVICE} # Name for local container management
     hostname: ${SERVICE} # Name used within your Tailscale environment
+    privileged: true
     environment:
       - TS_AUTHKEY=${TS_AUTHKEY}
       - TS_STATE_DIR=/var/lib/tailscale

--- a/services/cyberchef/docker-compose.yml
+++ b/services/cyberchef/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/ddns-updater/docker-compose.yml
+++ b/services/ddns-updater/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/dozzle/docker-compose.yml
+++ b/services/dozzle/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/excalidraw/docker-compose.yml
+++ b/services/excalidraw/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/gokapi/docker-compose.yml
+++ b/services/gokapi/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/homarr/docker-compose.yml
+++ b/services/homarr/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/isley/docker-compose.yml
+++ b/services/isley/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint

--- a/services/it-tools/docker-compose.yml
+++ b/services/it-tools/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/jellyfin/docker-compose.yml
+++ b/services/jellyfin/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/languagetool/docker-compose.yml
+++ b/services/languagetool/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/nextcloud/docker-compose.yml
+++ b/services/nextcloud/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/nodered/docker-compose.yml
+++ b/services/nodered/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/pihole/docker-compose.yml
+++ b/services/pihole/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/pingvin-share/docker-compose.yml
+++ b/services/pingvin-share/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/plex/docker-compose.yml
+++ b/services/plex/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/portainer/docker-compose.yml
+++ b/services/portainer/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/qbittorrent/docker-compose.yml
+++ b/services/qbittorrent/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/radarr/docker-compose.yml
+++ b/services/radarr/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/resilio-sync/docker-compose.yml
+++ b/services/resilio-sync/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/searxng/docker-compose.yml
+++ b/services/searxng/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/slink/docker-compose.yml
+++ b/services/slink/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/sonarr/docker-compose.yml
+++ b/services/sonarr/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/stirlingpdf/docker-compose.yml
+++ b/services/stirlingpdf/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/tailscale-exit-node/docker-compose.yml
+++ b/services/tailscale-exit-node/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     dns:
       - 1.1.1.1 # Can be changed to your desired DNS provider

--- a/services/tautulli/docker-compose.yml
+++ b/services/tautulli/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/technitium/docker-compose.yml
+++ b/services/technitium/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/traefik/docker-compose.yml
+++ b/services/traefik/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/uptime-kuma/docker-compose.yml
+++ b/services/uptime-kuma/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement

--- a/services/vaultwarden/docker-compose.yml
+++ b/services/vaultwarden/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${PWD}/${SERVICE}/ts/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/${SERVICE}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+    devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
     cap_add:
       - net_admin # Tailscale requirement


### PR DESCRIPTION
# Pull Request Title: [Short Description of Changes]

## Description

Moved `- /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work` to section `devices` 
 `tstun.New("tailscale0"): operation not permitted`

## Related Issues

- N/A

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Describe the tests you ran to verify your changes. Provide instructions for reproducing the testing process:

1. Local test cases - see screenshot with issue - resolved by adding the device specifically under `devices`

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix or feature works
- [X] I have updated necessary documentation (e.g. frontpage `README.md`)
- [X] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

If visual changes are made, include screenshots to demonstrate them.

<img width="655" alt="Screenshot 2025-01-03 at 16 28 32" src="https://github.com/user-attachments/assets/36a5b477-8c9b-4ba2-a4a4-fa1f1791cc86" />

