### PR TITLE
Removed double use of devices

### DIFF
--- a/services/tailscale-exit-node/docker-compose.yml
+++ b/services/tailscale-exit-node/docker-compose.yml
@@ -26,8 +26,6 @@ services:
     cap_add:
       - net_admin # Tailscale requirement
       - sys_module # Tailscale requirement
-    devices:
-      - /dev/net/tun
     network_mode: bridge
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:41234/healthz"] # Check Tailscale has a Tailnet IP and is operational


### PR DESCRIPTION
# Pull Request Title: Removed double use of devices

## Description

Fixed double mention of `devices` resulting in yaml error.

## Related Issues

- N/A/

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Describe the tests you ran to verify your changes. Provide instructions for reproducing the testing process:

```bash
$ docker compose up -d
yaml: unmarshal errors:
  line 29: mapping key "devices" already defined at line 19
```

The above issue was resolved by removing one mention of `devices` from the `docker-compose.yml`.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix or feature works
- [X] I have updated necessary documentation (e.g. frontpage `README.md`)
- [X] Any dependent changes have been merged and published in downstream modules
