### PR TITLE
Resolved interpretation issue for TS_AUTHKEY

### DIFF
--- a/services/adguardhome/.env
+++ b/services/adguardhome/.env
@@ -4,5 +4,5 @@
 SERVICE=adguardhome
 IMAGE_URL=adguard/adguardhome:latest
 SERVICEPORT=53
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/bazarr/.env
+++ b/services/bazarr/.env
@@ -4,5 +4,5 @@
 SERVICE=bazarr
 IMAGE_URL=lscr.io/linuxserver/bazarr:latest
 SERVICEPORT=6767
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/beszel/agent/.env
+++ b/services/beszel/agent/.env
@@ -4,5 +4,5 @@
 SERVICE=beszel-agent
 IMAGE_URL=henrygd/beszel-agent:latest
 SERVICEPORT=45876
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/beszel/hub/.env
+++ b/services/beszel/hub/.env
@@ -4,5 +4,5 @@
 SERVICE=beszel-hub
 IMAGE_URL=henrygd/beszel:latest
 SERVICEPORT=8090
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/changedetection/.env
+++ b/services/changedetection/.env
@@ -4,5 +4,5 @@
 SERVICE=changedetection
 IMAGE_URL=ghcr.io/dgtlmoon/changedetection.io
 SERVICEPORT=5000
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/cyberchef/.env
+++ b/services/cyberchef/.env
@@ -4,5 +4,5 @@
 SERVICE=cyberchef
 IMAGE_URL=ghcr.io/gchq/cyberchef
 SERVICEPORT=80
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/ddns-updater/.env
+++ b/services/ddns-updater/.env
@@ -4,5 +4,5 @@
 SERVICE=ddns-updater
 IMAGE_URL=qmcgaw/ddns-updater
 SERVICEPORT=8000
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/dozzle/.env
+++ b/services/dozzle/.env
@@ -4,5 +4,5 @@
 SERVICE=dozzle
 IMAGE_URL=amir20/dozzle
 SERVICEPORT=8080
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/excalidraw/.env
+++ b/services/excalidraw/.env
@@ -4,5 +4,5 @@
 SERVICE=excalidraw
 IMAGE_URL=excalidraw/excalidraw
 SERVICEPORT=80
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/gokapi/.env
+++ b/services/gokapi/.env
@@ -4,5 +4,5 @@
 SERVICE=gokapi
 IMAGE_URL=f0rc3/gokapi
 SERVICEPORT=53842
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/homarr/.env
+++ b/services/homarr/.env
@@ -4,5 +4,5 @@
 SERVICE=homarr
 IMAGE_URL=ghcr.io/ajnart/homarr
 SERVICEPORT=7575
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/isley/.env
+++ b/services/isley/.env
@@ -4,5 +4,5 @@
 SERVICE=isley
 IMAGE_URL=dwot/isley
 SERVICEPORT=8080
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/it-tools/.env
+++ b/services/it-tools/.env
@@ -4,5 +4,5 @@
 SERVICE=it-tools
 IMAGE_URL=corentinth/it-tools
 SERVICEPORT=80
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/jellyfin/.env
+++ b/services/jellyfin/.env
@@ -4,5 +4,5 @@
 SERVICE=jellyfin
 IMAGE_URL=lscr.io/linuxserver/jellyfin
 SERVICEPORT=8096
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/languagetool/.env
+++ b/services/languagetool/.env
@@ -4,5 +4,5 @@
 SERVICE=languagetool
 IMAGE_URL=erikvl87/languagetool
 SERVICEPORT=8010
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/nextcloud/.env
+++ b/services/nextcloud/.env
@@ -4,7 +4,7 @@
 SERVICE=nextcloud
 IMAGE_URL=nextcloud
 SERVICEPORT=80
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1
 MYSQL_ROOT_PASSWORD= //Insert super root strong password
 MYSQL_PASSWORD= //Insert super strong password

--- a/services/nodered/.env
+++ b/services/nodered/.env
@@ -4,5 +4,5 @@
 SERVICE=nodered
 IMAGE_URL=nodered/node-red:latest
 SERVICEPORT=1080
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/pihole/.env
+++ b/services/pihole/.env
@@ -4,5 +4,5 @@
 SERVICE=pihole
 IMAGE_URL=pihole/pihole
 SERVICEPORT=80
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/pingvin-share/.env
+++ b/services/pingvin-share/.env
@@ -4,5 +4,5 @@
 SERVICE=pingvin-share
 IMAGE_URL=stonith404/pingvin-share
 SERVICEPORT=3000
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/plex/.env
+++ b/services/plex/.env
@@ -4,5 +4,5 @@
 SERVICE=plex
 IMAGE_URL=lscr.io/linuxserver/plex
 SERVICEPORT=32400
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/portainer/.env
+++ b/services/portainer/.env
@@ -4,5 +4,5 @@
 SERVICE=portainer
 IMAGE_URL=portainer/portainer-ce
 SERVICEPORT=9000
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/qbittorrent/.env
+++ b/services/qbittorrent/.env
@@ -4,5 +4,5 @@
 SERVICE=qbittorrent
 IMAGE_URL=lscr.io/linuxserver/qbittorrent
 SERVICEPORT=8080
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/radarr/.env
+++ b/services/radarr/.env
@@ -4,5 +4,5 @@
 SERVICE=radarr
 IMAGE_URL=radarr/server
 SERVICEPORT=7878
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/resilio-sync/.env
+++ b/services/resilio-sync/.env
@@ -4,5 +4,5 @@
 SERVICE=resilio-sync
 IMAGE_URL=linuxserver/resilio-sync
 SERVICEPORT=8888
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/searxng/.env
+++ b/services/searxng/.env
@@ -4,5 +4,5 @@
 SERVICE=searxng
 IMAGE_URL=docker.io/searxng/searxng
 SERVICEPORT=8080
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/slink/.env
+++ b/services/slink/.env
@@ -4,5 +4,5 @@
 SERVICE=slink
 IMAGE_URL=anirdev/slink
 SERVICEPORT=3000
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/sonarr/.env
+++ b/services/sonarr/.env
@@ -4,5 +4,5 @@
 SERVICE=sonarr
 IMAGE_URL=lscr.io/linuxserver/sonarr
 SERVICEPORT=8989
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/stirlingpdf/.env
+++ b/services/stirlingpdf/.env
@@ -4,5 +4,5 @@
 SERVICE=stirlingpdf
 IMAGE_URL=frooodle/s-pdf
 SERVICEPORT=8080
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/tailscale-exit-node/.env
+++ b/services/tailscale-exit-node/.env
@@ -4,5 +4,5 @@
 SERVICE=tailscale-exit-node
 IMAGE_URL=tailscale/tailscale
 #SERVICEPORT=80
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/tautulli/.env
+++ b/services/tautulli/.env
@@ -4,5 +4,5 @@
 SERVICE=tautulli
 IMAGE_URL=lscr.io/linuxserver/tautulli
 SERVICEPORT=8181
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/technitium/.env
+++ b/services/technitium/.env
@@ -1,7 +1,7 @@
 #version=1.0
 #url=https://github.com/2Tiny2Scale/tailscale-docker-sidecar-configs
 #COMPOSE_PROJECT_NAME= // only use in multiple deployments on the same infra
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 SERVICE=technitium
 IMAGE_URL=technitium/dns-server:latest
 SERVICEPORT=5380

--- a/services/traefik/.env
+++ b/services/traefik/.env
@@ -4,5 +4,5 @@
 SERVICE=traefik
 IMAGE_URL=traefik:latest
 SERVICEPORT=80
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/uptime-kuma/.env
+++ b/services/uptime-kuma/.env
@@ -4,5 +4,5 @@
 SERVICE=uptime-kuma
 IMAGE_URL=louislam/uptime-kuma
 SERVICEPORT=3001
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1

--- a/services/vaultwarden/.env
+++ b/services/vaultwarden/.env
@@ -4,5 +4,5 @@
 SERVICE=vaultwarden
 IMAGE_URL=vaultwarden/server
 SERVICEPORT=80
-TS_AUTHKEY= //Insert Tailscale key here from the Admin Portal
+TS_AUTHKEY=
 DNS_SERVER=1.1.1.1


### PR DESCRIPTION
# Pull Request Title: Resolved interpretation issue for `TS_AUTHKEY`

## Description

Due to text ` //Insert Tailscale key here from the Admin Portal` in `TS_AUTHKEY=` in `.env` the inserted key is misinterpreted. Removing this placeholder text solves the issue. This PR removes the placeholder text for all services.

## Related Issues

- N/A

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Describe the tests you ran to verify your changes. Provide instructions for reproducing the testing process:

Starting container with the following `.env` configuration will result in machine **not connecting** to Tailscale environment.

```plain
$ cat .env 
#version=1.0
#url=https://github.com/2Tiny2Scale/tailscale-docker-sidecar-configs
#COMPOSE_PROJECT_NAME= // only use in multiple deployments on the same infra
SERVICE=tailscale-exit-node
IMAGE_URL=tailscale/tailscale
#SERVICEPORT=80
TS_AUTHKEY=tskey-auth-k8XegbkCHf11CNTRL-HM[...REDACTED...]QF //Insert Tailscale key here from the Admin Portal
DNS_SERVER=1.1.1.1
```

Starting container with the following `.env` configuration will result in machine connecting to Tailscale environment.

```plain
$ cat .env 
#version=1.0
#url=https://github.com/2Tiny2Scale/tailscale-docker-sidecar-configs
#COMPOSE_PROJECT_NAME= // only use in multiple deployments on the same infra
SERVICE=tailscale-exit-node
IMAGE_URL=tailscale/tailscale
#SERVICEPORT=80
TS_AUTHKEY=tskey-auth-k8XegbkCHf11CNTRL-HM[...REDACTED...]QF
DNS_SERVER=1.1.1.1
```

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix or feature works
- [X] I have updated necessary documentation (e.g. frontpage `README.md`)
- [X] Any dependent changes have been merged and published in downstream modules
